### PR TITLE
Allow deleting study sessions when original message has been deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **User Authorization**
   - Allows moderators to post multiple non-link messages in link channels without being warned/muted.
   - Prevents regular users from using moderator commands.
-  
+
 - **Expletive Filter**
   - Immediately filters messages that include expletives and replaces them with clean version of original messages.
 
@@ -25,7 +25,7 @@
   - Provides weekly vocabulary words to users to type in Korean and times how quickly they are able to type them out in Korean.
 
 - **Keep Pinned Messages Under 50**
-  - Automatically unpins oldest message when a channel reaches its 50 pin limit.  
+  - Automatically unpins oldest message when a channel reaches its 50 pin limit.
 
 - **Manage Study Session**
   - Create study sessions that other users can subscribe to.
@@ -41,6 +41,7 @@
 | **Check if bot is running** |  Everyone  | <br>**Wake up! @`Bot's name`** <br><br> |
 | **Start Korean Typing Exercise** |  Everyone  | <br>**@`Bot's name` typing<br><br>***- OR -***<br><br>!t**<br><br> |
 | **Create Study Session** |  Everyone  | <br>**!study `A message that includes: YYYY/MM/DD and HH:mm am/pm (ex. 2021/01/25 02:00 am)`**<br><br> |
+| **Cancel Study Session** |  Everyone  | <br>**!cancel study `A message that includes: YYYY/MM/DD and HH:mm am/pm (ex. 2021/01/25 02:00 am)`**<br><br> |
 | **List Upcoming Study Sessions** |  Everyone  | <br>**!upcoming study**<br><br> |
 | **Move all pinned messages to another channel**|  Moderators   | <br> **@`Bot's name` copy the pins here<br>@`Bot's name` paste the pins here** <br><br>  |
 | **Manually Unmute users** *(used for emergencies if user is stuck on mute)* |  Moderators  | <br>**Unmute @`User's name`<br>***(This unmutes a single user)***<br><br>***- OR -***<br><br>Unmute everyone @`Bot's name`<br>** *(This unmutes everyone)*<br><br>|

--- a/src/constants/studySession.js
+++ b/src/constants/studySession.js
@@ -73,6 +73,14 @@ const STUDY_SESSION = {
 			description: `Oops! An error as occurred while cancelling the study session. Please try again!${error ? `\n\n*${error}*` : ""}`,
 		}),
 		UNAUTHORIZED: { content: "❌ Hep! Only the study session's owner can cancel the session." },
+		NOT_FOUND: {
+			title: "🙈 No sessions found",
+			description: "Oops! Looks like you haven't created any sessions at that time.",
+		},
+		MISSING_DATE: {
+			title: "📆 Missing date",
+			description: "Please provide a valid date!\n\n*The accepted format is `YYYY/MM/DD` for the date and `HH:mm` for the time.*",
+		},
 	},
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const { regularQualifyCheck } = require("./scripts/users/user-utilities");
 const { unPin50thMsg, getAllChannels, logMessageDate, ping } = require("./scripts/utilities");
 const { addBookmark, removeBookmark } = require("./scripts/bookmarks");
 const { typingGame, typingGameListener, endTypingGame, gameExplanation } = require("./scripts/activities/games");
-const { createStudySession, getUpcomingStudySessions, subscribeStudySession, unsubscribeStudySession, cancelConfirmationStudySession } = require("./scripts/activities/study-session");
+const { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession, cancelConfirmationStudySession } = require("./scripts/activities/study-session");
 const { loadMessageReaction } = require("./utils/cache");
 const runScheduler = require("./scheduler").default;
 /* ------------------------------------------------------ */
@@ -72,7 +72,7 @@ client.on("message", (message) => {
 
 	// Sends typing game explanation to exercise channel
 	gameExplanation(message);
-	
+
 	if (text.includes("wake up") && text.includes(process.env.CLIENT_ID)) {
 		// Bot's ID
 		ping(message);
@@ -137,8 +137,21 @@ client.on("message", (message) => {
 
 	// Find upcoming study sessions
 	if (text.startsWith("!upcoming study")) getUpcomingStudySessions(message);
+
+	if (text.startsWith("!cancel study")) {
+		cancelStudySessionFromCommand(message);
+		return;
+	}
 });
 /* --------------------------------------------------- */
+
+client.on("messageDelete", (message) => {
+	const text = message.content.toLowerCase();
+	if (text.startsWith("!study")) {
+		cancelStudySessionFromDeletion(message);
+		return;
+	}
+});
 
 /* ________________ MAIN MESSAGE REACTION ADD LISTENER ________________ */
 


### PR DESCRIPTION
Currently users are able to delete their original study session message, but this doesn't delete the study session so it continues to show up in the upcoming study sessions list

In this commit I add the ability to cancel study sessions via a `!cancel study` command, which takes in the date and time of the session to be deleted. Only the creator of a study session can delete their study session

In addition to this I made it so that deleting a study session message results in the cancellation of a study session (since once that message is deleted nobody can subscribe anyway)

To prevent overly frequent calls to the DB on message deletion I've restricted it to only the ones which match the assumption that the message begins with "!study" but because we're able to edit those messages after the fact, this may sometimes not be true - For those cases, the explicit cancellation command should still do the trick