### PR TITLE
Ensure message content exists before calling string methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ client.on("ready", () => {
 
 client.on("message", (message) => {
 	if (isMessageIgnored(message)) return;
-	const text = message.content.toLowerCase();
+	const text = getContent(message).toLowerCase();
 
 	// Filters Explicit Words
 	if (explicitWordFilter(message)) {
@@ -145,8 +145,12 @@ client.on("message", (message) => {
 });
 /* --------------------------------------------------- */
 
+function getContent(message) {
+	return message.content ? message.content : "";
+}
+
 client.on("messageDelete", (message) => {
-	const text = message.content.toLowerCase();
+	const text = getContent(message).toLowerCase();
 	if (text.startsWith("!study")) {
 		cancelStudySessionFromDeletion(message);
 		return;
@@ -160,7 +164,7 @@ client.on("messageReactionAdd", async (messageReaction, user) => {
 	if (messageReaction.partial) await loadMessageReaction(messageReaction);
 
 	const { message, emoji } = messageReaction;
-	const text = message.content.toLowerCase();
+	const text = getContent(message).toLowerCase();
 
 	// Don't intercept Bot's reactions
 	if (user.id === client.user.id) return;
@@ -184,7 +188,7 @@ client.on("messageReactionRemove", async (messageReaction, user) => {
 	// If the server has restarted, messages may not be cached
 	if (messageReaction.partial) await loadMessageReaction(messageReaction);
 	const { message, emoji } = messageReaction;
-	const text = message.content.toLowerCase();
+	const text = getContent(message).toLowerCase();
 
 	// Don't intercept Bot's reactions
 	if (user.id === client.user.id) return;

--- a/src/scripts/activities/games.js
+++ b/src/scripts/activities/games.js
@@ -327,7 +327,7 @@ function endTypingGame(message) {
 
 /* ___________________ Sends Game Explanation Message _________________ */
 function gameExplanation(message) {
-	const text = message.content;
+	const text = getContent(message);
 	// Sends typing game explanation
 	if (message.channel.id === process.env.EXERCISES_CHANNEL) {
 		clearTimeout(global.noResponseTimeout);
@@ -355,5 +355,9 @@ function gameExplanation(message) {
 	}
 }
 /* ------------------------------------------------- */
+
+function getContent(message) {
+	return message.content ? message.content : "";
+}
 
 module.exports = { typingGame, typingGameListener, endTypingGame, gameExplanation };

--- a/src/scripts/expletives.js
+++ b/src/scripts/expletives.js
@@ -63,7 +63,7 @@ const englishKoreanRegex = /([\w]+|[\x00-\x7F\x80-\xFF\u0100-\u017F\u0180-\u024F
 
 /* Checks if message has expletives */
 function check(message) {
-	let contentArray = message.content.split(englishKoreanRegex);
+	let contentArray = getContent(message).split(englishKoreanRegex);
 
 	let foundExpletive = false;
 	contentArray.forEach((word, index) => {
@@ -88,6 +88,10 @@ function check(message) {
 	});
 	newMessage = contentArray.join("");
 	return foundExpletive;
+}
+
+function getContent(message) {
+	return message.content ? message.content : "";
 }
 
 /* Replaces characters used to get around expletive filters */

--- a/src/scripts/resource-channels.js
+++ b/src/scripts/resource-channels.js
@@ -81,8 +81,12 @@ function resourcesMuteMessage(message, client) {
 
 function checkIfResource(message) {
 	if (message.attachments.size) return true; // Ignores attachments
-	if (message.content.includes("http")) return true; // Ignores all links
+	if (getContent(message).includes("http")) return true; // Ignores all links
 	return false;
+}
+
+function getContent(message) {
+	return message.content ? message.content : "";
 }
 
 module.exports = { resourcesObserver };


### PR DESCRIPTION
To handle #28, where messages which included attachments but no text were causing the script to halt

Ensuring there is a string being operated on rather than doing early returns to maintain any previous behaviour which assumed that all messages had content, even if empty