### PR TITLE
Increase wait time for game explanation

### DIFF
--- a/src/scripts/activities/games.js
+++ b/src/scripts/activities/games.js
@@ -375,7 +375,7 @@ function gameExplanation(message) {
 		clearTimeout(global.explanationTimeout);
 		global.explanationTimeout = setTimeout(() => {
 			sendResponse(message);
-		}, 10000);
+		}, 20000);
 	}
 	function sendResponse(message) {
 		message.channel.send("...uhh,\n\nAhem... If you would like to start the typing exercise, you can type:\n\n<@!784522323755663411> `typing`\n- ***OR*** -\n`!t`");


### PR DESCRIPTION
The explanation message showing how to play the game was set to a very low timeout and resulting in a less than desirable user experience when not typing fast enough. 😅 

Increased the wait time from 10 to 20 seconds.