### PR TITLE
Fix study session estimated length bugs

### DIFF
--- a/src/scripts/activities/study-session.js
+++ b/src/scripts/activities/study-session.js
@@ -17,14 +17,14 @@ function getStudySessionDate(text) {
 
 function getStudySessionEstimatedLength(text) {
 	// Regex Declaration
-	const hoursRgx = /(\d)\s?hour/; // h hour(s)
-	const minutesRgx = /(\d{1,2})\s?min/; // mm min(utes)
+	const hoursRgx = /(\d+)\s?hour/; // h hour(s)
+	const minutesRgx = /(\d+)\s?min/; // mm min(utes)
 
 	// Catching information from message
-	const estimatedLengthHours = hoursRgx.exec(text)?.[1];
-	const estimatedLengthMinutes = minutesRgx.exec(text)?.[1];
+	const estimatedLengthHours = hoursRgx.exec(text)?.[1] ?? 0;
+	const estimatedLengthMinutes = minutesRgx.exec(text)?.[1] ?? 0;
 
-	return estimatedLengthHours ? estimatedLengthHours * 60 : estimatedLengthMinutes;
+	return (Number(estimatedLengthHours) * 60) + Number(estimatedLengthMinutes);
 }
 
 // Retrieve Study Session information from message


### PR DESCRIPTION
Study session estimated lengths previously didn't support both hours and minutes for estimated lengths (one or the other)

They also only supported single-digit hour values and double-digit minute values (so 13 hours is parsed as 3 hours, 180 minutes is parsed as 80 minutes)

Fixing an issue that was reported here: https://discord.com/channels/782201995011817493/793224619012128779/847688441814450176

Because I know for sure this message will eventually be deleted, it reads
"I think the bot might be getting the duration of study sessions off, I'm not sure if it's a known issue, could we get this fixed?"
And an image attached showing three study session creations:
Input 1 hour 40 minutes -> Estimated length 60 minutes
Input 13 hours -> Estimated length 180 minutes
Input 1 hour 50 minutes -> Estimated length 60 minutes