### PR TITLE
Add new timezone conversion command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "discord.js": "^12.5.1",
     "dotenv": "^8.2.0",
     "googleapis": "^39.2.0",
+    "luxon": "^1.27.0",
     "mongoose": "^5.11.8",
     "node-cron": "^2.0.3"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ const { addBookmark, removeBookmark } = require("./scripts/users/dm/bookmarks");
 const { unPin50thMsg, getAllChannels, ping } = require("./scripts/utilities");
 const { typingGame, typingGameListener, endTypingGame, gameExplanation } = require("./scripts/activities/games");
 const { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession, cancelConfirmationStudySession } = require("./scripts/activities/study-session");
+const { convertBetweenTimezones } = require("./scripts/utility-commands/time-and-date");
 const { loadMessageReaction } = require("./utils/cache");
 const runScheduler = require("./scheduler").default;
 /* ------------------------------------------------------ */
@@ -142,6 +143,11 @@ client.on("message", (message) => {
 
 	if (text.startsWith("!cancel study")) {
 		cancelStudySessionFromCommand(message);
+		return;
+	}
+
+	if (text.startsWith("!timezone")) {
+		convertBetweenTimezones(message);
 		return;
 	}
 });

--- a/src/scripts/utility-commands/time-and-date.js
+++ b/src/scripts/utility-commands/time-and-date.js
@@ -1,0 +1,52 @@
+const { DateTime } = require("luxon");
+
+function convertBetweenTimezones(message) {
+    let text = message.content ?? "";
+    if (text.length < 10) {
+        return;
+    }
+    text = text.substring(9).trim();
+
+    const dateTime = getDateTimeFromMessage(text);
+    if (dateTime === null) {
+        message.reply("please provide a valid datetime in the format YYYY/MM/DD HH:mm");
+        return;
+    }
+
+    const timezones = getTimeZonesFromMessage(text);
+    if (timezones === null || timezones.length === 0) {
+        message.reply("please provide at least one valid timezone to convert to. \n\nFor a list of valid timezones see the *'TZ database name'* column in this table here: <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List>");
+        return;
+    }
+
+    let convertedTimes = [];
+    timezones.forEach(timezone => {
+        const convertedTime = dateTime.setZone(timezone);
+        if (convertedTime.invalid === null) {
+            const timeZoneAbbreviation = convertedTime.offsetNameLong;
+            const dateTimeString = `${convertedTime.weekdayShort}, ${convertedTime.day} ${convertedTime.monthShort} at ${convertedTime.toFormat('HH:mm')} *(${timeZoneAbbreviation})*`;
+            convertedTimes.push(dateTimeString);
+        }
+    });
+
+    message.channel.send(convertedTimes.join('\n'));
+}
+
+function getDateTimeFromMessage(text) {
+    const dateRgx = /(\d{4}[-|\/]\d{2}[-|\/]\d{2})/g; // YYYY-MM-DD | YYYY/MM/DD
+    const timeRgx = /(?<time>\d{1,2}:\d{2})\s?(?<meridian>(am|pm)\b)?/gi; // HH:mm | HH:mm am | HH:mm pm
+    const date = dateRgx.exec(text)?.[1];
+    const { time, meridian = "" } = timeRgx.exec(text)?.groups ?? {};
+    const jsDate = new Date(`${date} ${time} ${meridian} +00:00`);
+    if (isNaN(jsDate.getTime())) {
+        return null;
+    }
+    return DateTime.fromISO(jsDate.toISOString());
+}
+
+function getTimeZonesFromMessage(text) {
+    const timezoneRegex = /([A-Za-z]+[\/][A-Za-z0-9_\-+]*)/g;
+    return text.match(timezoneRegex);
+}
+
+module.exports = { convertBetweenTimezones };


### PR DESCRIPTION
- Added new command, `!timezone` which takes in a datetime and responds with conversions for the supplied timezones

Format:
`!timezone {date} {time} {timezones}`
Where
`{date}` is in the format YYYY/MM/DD
`{time}` is in the format HH:mm or hh:mm am|pm
`{timezones}` are one or more valid IANA TZ database timezones

Example input:
```
!timezone 2021/05/02 11:30 pm America/Toronto Asia/Makassar Europe/London
```
Output:
```
Sun, 2 May at 19:30 (Eastern Daylight Time)
Mon, 3 May at 07:30 (Central Indonesia Time)
Mon, 3 May at 00:30 (British Summer Time)
```

This PR also introduces the luxon package to handle the timezone conversions