### PR TITLE
Remove the ❌ reaction study session cancellation feature

### DIFF
--- a/src/constants/studySession.js
+++ b/src/constants/studySession.js
@@ -6,7 +6,7 @@ const STUDY_SESSION = {
 		SUCCESS: (session) => ({
 			title: "STUDY SESSION",
 			content: "Study session has been registered successfully!",
-			description: `📆 ${getUTCFullDate(session.startDate, "date")} at ${getUTCFullDate(session.startDate, "time")} *(UTC)*\n🕑 Estimated length: ${session.estimatedLength} minutes.\n\n${session.message?.text}\n\n*If anybody wants to join the session, subscribe using the ⭐ button\nIf you want to cancel the session, press the ❌ button*`,
+			description: `📆 ${getUTCFullDate(session.startDate, "date")} at ${getUTCFullDate(session.startDate, "time")} *(UTC)*\n🕑 Estimated length: ${session.estimatedLength} minutes.\n\n${session.message?.text}\n\n*If anybody wants to join the session, subscribe using the ⭐ button\nIf you want to cancel the session, delete the message used to create it*`,
 			withAuthor: true,
 		}),
 		ERROR: (error) => ({

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const { isDm, handleDmReactionAdd } = require("./scripts/users/dm/dm");
 const { addBookmark, removeBookmark } = require("./scripts/users/dm/bookmarks");
 const { unPin50thMsg, getAllChannels, ping } = require("./scripts/utilities");
 const { typingGame, typingGameListener, endTypingGame, gameExplanation } = require("./scripts/activities/games");
-const { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession, cancelConfirmationStudySession } = require("./scripts/activities/study-session");
+const { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession } = require("./scripts/activities/study-session");
 const { loadMessageReaction } = require("./utils/cache");
 const runScheduler = require("./scheduler").default;
 /* ------------------------------------------------------ */
@@ -180,9 +180,6 @@ client.on("messageReactionAdd", async (messageReaction, user) => {
 
 	// Subscribe to a study session
 	if (text.startsWith("!study") && emoji.name === "⭐") subscribeStudySession(message, user);
-
-	// Cancel study session
-	if (text.startsWith("!study") && emoji.name === "❌") cancelConfirmationStudySession(message, user);
 });
 /* --------------------------------------------------- */
 

--- a/src/scripts/activities/study-session.js
+++ b/src/scripts/activities/study-session.js
@@ -57,7 +57,7 @@ function createStudySession(message) {
 	StudySession.create(studySession)
 		.then(() => {
 			replySuccess(message, STUDY_SESSION.CREATE.SUCCESS(studySession));
-			react(message, null, ["⭐", "❌"]);
+			react(message, null, ["⭐"]);
 		})
 		.catch((error) => replyError(message, STUDY_SESSION.CREATE.ERROR(error)));
 }
@@ -93,22 +93,6 @@ function notifySubscribers(client, studySession) {
 	});
 }
 
-function cancelConfirmationStudySession(message, user) {
-	if (message.author.id !== user.id) return replyError(message, STUDY_SESSION.CANCEL.UNAUTHORIZED);
-	replySurvey(message, STUDY_SESSION.CANCEL.CONFIRMATION(user), ["✅", "❌"], 60000)
-		.then((result) => {
-			switch (result) {
-				case "✅":
-					return cancelStudySession(message);
-				case "❌":
-					return replyInfo(message, STUDY_SESSION.CANCEL.CANCEL);
-				default:
-					return replyInfo(message, STUDY_SESSION.CANCEL.TIME_ELAPSED);
-			}
-		})
-		.catch((error) => replyError(message, STUDY_SESSION.CANCEL.ERROR(error)));
-}
-
 function cancelNotifySubscribers(message, studySession) {
 	if (studySession.subscribersId?.length > 0)
 		return studySession.subscribersId.map((subscriberId) => {
@@ -117,17 +101,6 @@ function cancelNotifySubscribers(message, studySession) {
 				.then((subscriber) => sendDirectMessage(subscriber, STUDY_SESSION.CANCEL.NOTIFICATION(message.author, subscriber)))
 				.catch((error) => replyError(message, STUDY_SESSION.CANCEL.ERROR(error)));
 		});
-}
-
-function cancelStudySession(message) {
-	StudySession.findOne({ "message.id": message.id }, (error, studySession) => {
-		if (error) return replyError(message, STUDY_SESSION.CANCEL.ERROR(error));
-		cancelNotifySubscribers(message, studySession);
-		studySession
-			.remove()
-			.then(() => replySuccess(message, studySession.subscribersId.length > 0 ? STUDY_SESSION.CANCEL.SUCCESS_WITH_SUBSCRIBERS(message.author) : STUDY_SESSION.CANCEL.SUCCESS(message.author)))
-			.catch((error) => replyError(message, STUDY_SESSION.CANCEL.ERROR(error)));
-	});
 }
 
 function cancelStudySessionFromCommand(message) {
@@ -164,4 +137,4 @@ function cancelStudySessionFromDeletion(message) {
 	});
 }
 
-module.exports = { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession, notifySubscribers, cancelConfirmationStudySession };
+module.exports = { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession, notifySubscribers };


### PR DESCRIPTION
It was far too easy for people to create unauthorized requests using the ❌ reaction when they either didn't know what it was for (clicking it to show that they don't want to attend the session?) or, more commonly, clicking it "maliciously" to have the unauthorized request message ("Only the study session owner can cancel a session") pop up in the chat. 

Little bit annoying, and we have other ways of cancelling study sessions that don't require member checks, so just removing this