### PR TITLE
Create a 'title' section for study sessions

### DIFF
--- a/src/constants/studySession.js
+++ b/src/constants/studySession.js
@@ -6,7 +6,7 @@ const STUDY_SESSION = {
 		SUCCESS: (session) => ({
 			title: "STUDY SESSION",
 			content: "Study session has been registered successfully!",
-			description: `📆 ${getUTCFullDate(session.startDate, "date")} at ${getUTCFullDate(session.startDate, "time")} *(UTC)*\n🕑 Estimated length: ${session.estimatedLength} minutes.\n\n${session.message?.text}\n\n*If anybody wants to join the session, subscribe using the ⭐ button\nIf you want to cancel the session, delete the message used to create it*`,
+			description: `📆 ${getUTCFullDate(session.startDate, "date")} at ${getUTCFullDate(session.startDate, "time")} *(UTC)*\n🕑 Estimated length: ${session.estimatedLength} minutes.\n\n${getStudySessionText(session.message)}\n\n*If anybody wants to join the session, subscribe using the ⭐ button\nIf you want to cancel the session, delete the message used to create it*`,
 			withAuthor: true,
 		}),
 		ERROR: (error) => ({
@@ -32,7 +32,7 @@ const STUDY_SESSION = {
 			content: "Here are the upcoming study sessions:\n*Make sure to check the time zones!*",
 			fields: sessions.map((session) => ({
 				name: `${session.author.username}'s study session`,
-				value: `*${getUTCFullDate(session.startDate)} UTC (${session.estimatedLength} min)*\n${session.message?.text} - Subscribe [here](${session.message?.link})`,
+				value: `*${getUTCFullDate(session.startDate)} UTC (${session.estimatedLength} min)*\n${getUpcomingStudySessionSummary(session.message)} - Subscribe [here](${session.message?.link})`,
 			})),
 		}),
 		ERROR: (error) => ({
@@ -86,5 +86,35 @@ const STUDY_SESSION = {
 		},
 	},
 };
+
+function getStudySessionText(message) {
+	if (!message || !message.text) {
+		return "";
+	}
+	const lines = message.text.split("\n");
+	if (lines.length < 2) {
+		return lines[0];
+	}
+	return lines.splice(1, lines.length - 1).join("\n");
+}
+
+function getUpcomingStudySessionSummary(message) {
+	if (!message || !message.text) {
+		return "";
+	}
+
+	const text = message.text;
+	const firstLine = text.split("\n", 1)[0].trim();
+	if (firstLine.length > 0) {
+		return firstLine;
+	}
+
+	const contentOnSingleLine = text.split("\n").join(" ").trim();
+	const truncatedString = contentOnSingleLine.split(" ").splice(0, 8).join(" ");
+	if (contentOnSingleLine.length > truncatedString.length + 3) {
+		return truncatedString + "...";
+	}
+	return truncatedString;
+}
 
 module.exports = { STUDY_SESSION };

--- a/src/scripts/utilities.js
+++ b/src/scripts/utilities.js
@@ -175,6 +175,7 @@ function handleHelpStudyCommand(message) {
 					name: 'Format',
 					value: `
 The study command requires
+- a title placed on the first line (beside the \`!study\` command)
 - a date in the format YYYY/MM/DD
 - a UTC time in HH:mm
 - a session length in H hours, mm minutes or a combination of both
@@ -186,7 +187,8 @@ This message should also contain a description of the session
 					value: `
 Sending a message like this:
 \`\`\`
-!study 2022/03/05 at 13:30 for 1 hour
+!study Grammar lesson
+2022/03/05 at 13:30 for 1 hour
 We'll be studying some fundamental Korean grammar!
 \`\`\`
 Results in the bot creating a study session and responding with a message that looks like this:

--- a/src/tasks/studySession/channelReminder.js
+++ b/src/tasks/studySession/channelReminder.js
@@ -69,7 +69,7 @@ function makeStudySessionMessage() {
                 title: "UPCOMING STUDY SESSIONS",
                 fields: upcomingStudySessions.map((session) => ({
                     name: `${session.author.username}'s study session`,
-                    value: `*${getUTCFullDate(session.startDate)} UTC (${session.estimatedLength} min)*\n${session.message?.text} - Subscribe [here](${session.message?.link})`,
+                    value: `*${getUTCFullDate(session.startDate)} UTC (${session.estimatedLength} min)*\n${getUpcomingStudySessionSummary(session.message)} - Subscribe [here](${session.message?.link})`,
                 })),
                 color: "GREEN"
             }
@@ -77,6 +77,25 @@ function makeStudySessionMessage() {
     }).catch((error) => {
         console.log(error);
     });
+}
+
+function getUpcomingStudySessionSummary(message) {
+    if (!message || !message.text) {
+        return "";
+    }
+
+    const text = message.text;
+    const firstLine = text.split("\n", 1)[0].trim();
+    if (firstLine.length > 0) {
+        return firstLine;
+    }
+
+    const contentOnSingleLine = text.split("\n").join(" ").trim();
+    const truncatedString = contentOnSingleLine.split(" ").splice(0, 8).join(" ");
+    if (contentOnSingleLine.length > truncatedString.length + 3) {
+        return truncatedString + "...";
+    }
+    return truncatedString;
 }
 
 function createNotFoundMessage() {


### PR DESCRIPTION
The first line of a study session can be used as a title to be used in the 'upcoming study' message so that it doesn't get too cluttered with information. If there's no title supplied the message is still truncated to fit on a line or two

```
!study Do some reading
2021/07/12 23:00 1 hour
We'll be reading some beginner Korean texts from example.com
```
Would result in the same study session message showing up on creation but when running `!upcoming study` it would show up like this:
```
User's study session
Date Time (Length)
Do some reading - Subscribe here
```
Instead of the previous
```
User's study session
Date Time (Length)
Do some reading
2021/07/12 23:00 1 hour
We'll be reading some beginner Korean texts from example.com - Subscribe here
```