### PR TITLE
Filter expletives in edited messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,9 +148,9 @@ client.on("message", (message) => {
 
 	if (text.startsWith("!help")) {
 		handleHelpCommand(message);
-    return;
-  }
-  
+		return;
+	}
+
 	if (text.startsWith("!timezone")) {
 		convertBetweenTimezones(message);
 		return;
@@ -158,6 +158,9 @@ client.on("message", (message) => {
 });
 /* --------------------------------------------------- */
 
+client.on("messageUpdate", (oldMessage, newMessage) => {
+	explicitWordFilter(newMessage);
+});
 
 client.on("messageDelete", (message) => {
 	const text = (message.content ?? "").toLowerCase();


### PR DESCRIPTION
Handles the workaround where a message could be edited to contain expletives and wouldn't be filtered out