### PR TITLE
Refactor games.js for extensibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,14 +94,14 @@ client.on("message", (message) => {
 
 	// --- EXERCISES ---
 	switch (true) {
+		case gameIsRunning():
+			gameListener(message);
+			break;
 		case shouldStartGame(message, client):
 			startGame(message);
 			break;
 		case text.includes(process.env.CLIENT_ID) && text.includes("stop"):
 			endGame(message, true);
-			break;
-		case gameIsRunning():
-			gameListener(message);
 			break;
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,8 @@ const { manualUnMute } = require("./scripts/users/permissions");
 const { regularQualifyCheck } = require("./scripts/users/user-utilities");
 const { isDm, handleDmReactionAdd } = require("./scripts/users/dm/dm");
 const { addBookmark, removeBookmark } = require("./scripts/users/dm/bookmarks");
-const { unPin50thMsg, getAllChannels, ping, handleHelpCommand } = require("./scripts/utilities");
-const { typingGame, typingGameListener, endTypingGame, gameExplanation } = require("./scripts/activities/games");
+const { unPin50thMsg, getAllChannels, ping, isKoreanChannel, isLinksChannel, handleHelpCommand } = require("./scripts/utilities");
+const { gameExplanation, shouldStartGame, startGame, endGame, gameIsRunning, gameListener } = require("./scripts/activities/games");
 const { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession, updateStudySessionDetails } = require("./scripts/activities/study-session");
 const { convertBetweenTimezones } = require("./scripts/utility-commands/time-and-date");
 const { loadMessageReaction } = require("./utils/cache");
@@ -41,8 +41,6 @@ function isMessageIgnored(message) {
 	if (message.type === "PINS_ADD") return true; // Ignores PIN messages
 	return false;
 }
-
-global.tgFirstRoundStarted = false; // Flag for Typing Game below
 /* -------------------------------------------------------- */
 
 /* ________________ INITIATING FUNCTION ________________ */
@@ -95,21 +93,15 @@ client.on("message", (message) => {
 	}
 
 	// --- EXERCISES ---
-	let wroteStopFlag = false;
-
 	switch (true) {
-		// Start Typing Game
-		case (text.includes(process.env.CLIENT_ID) && text.includes("typing")) || text === "!t" || text === "!ㅌ":
-			typingGame(message, client);
+		case shouldStartGame(message, client):
+			startGame(message);
 			break;
-		// Stop Typing Game
 		case text.includes(process.env.CLIENT_ID) && text.includes("stop"):
-			wroteStopFlag = true;
-			endTypingGame(message, wroteStopFlag);
+			endGame(message, true);
 			break;
-		// Pass Message to Listener (while exercise is in progress)
-		case global.typingFlag === true:
-			typingGameListener(message, client);
+		case gameIsRunning():
+			gameListener(message);
 			break;
 	}
 
@@ -126,12 +118,12 @@ client.on("message", (message) => {
 
 	// Ensure long conversations in English aren't being had in Korean Channel
 	const channel = message.channel;
-	if (channel.id === process.env.KOREAN_CHANNEL) {
+	if (isKoreanChannel(channel)) {
 		koreanObserver(message, chnlMsgs, client);
 	}
 
 	// Ensure long conversations aren't being had in Resource Channel
-	if (channel.id === process.env.LINKS_CHANNEL) {
+	if (isLinksChannel(channel)) {
 		resourcesObserver(message, users, client);
 	}
 

--- a/src/scripts/activities/games.js
+++ b/src/scripts/activities/games.js
@@ -74,9 +74,12 @@ function containsCommandForGame(messageContent, gameName) {
 	if (messageContent.includes(process.env.CLIENT_ID) && messageContent.includes(GAMES[gameName].commands.long)) {
 		return true;
 	}
-	if (messageContent.endsWith(GAMES[gameName].commands.short)) {
+	const shortCommand = GAMES[gameName].commands?.short;
+	const hangulCommand = GAMES[gameName].commands?.hangul;
+	if (messageContent.endsWith(shortCommand) || messageContent.endsWith(hangulCommand)) {
 		return true;
 	}
+	
 	return false;
 }
 

--- a/src/scripts/activities/games.js
+++ b/src/scripts/activities/games.js
@@ -1,200 +1,143 @@
-/* ________________ Vocab Words _______________ */
+const { isExercisesChannel } = require("./../utilities");
 
-/* --------------------------------------- */
+const typingGame = require("./typing-game");
 
-const GoogleSheets = require("../../connections/google-sheets-conn");
-
-/* ____________ Main Typing Game Function ____________ */
-
-async function typingGame(message, client) {
-	if (message.channel.id !== process.env.EXERCISES_CHANNEL) {
-		client.channels.fetch(process.env.EXERCISES_CHANNEL).then((exerciseChannel) => {
-			message.reply(`Psst...I think you meant to send this in the ${exerciseChannel} channel.\nBut don't worry, no one noticed!`);
-		});
-		return;
-	}
-
-	try {
-		// Creates Global Typing Game object
-		global.typingGame = global.typingGame || {};
-
-		// Checks if waiting to receive input from users
-		if (typeof global.typingGame.listenerFlag === "undefined" || global.typingGame.listenerFlag) {
-			endTypingGame(message);
-		}
-
-		// Sets flag showing game is in play to true
-		global.typingFlag = true;
-
-		/* Immediately sets listener flag to true at the start of each round */
-		global.typingGame.listenerFlag = true;
-
-		const { word, definition } = await getVocab(message);
-
-		if (!global.tgFirstRoundStarted) {
-			setTimeout(() => message.channel.send(`So you're professor fasty fast. :smirk:\nWell let's see you type this word in Korean then!`), 1000);
-			setTimeout(
-				() =>
-					message.channel.send("I'll give you the first word in **5**").then((msg) => {
-						setTimeout(() => msg.edit("I'll give you the first word in **4**"), 1000);
-						setTimeout(() => msg.edit("I'll give you the first word in **3**"), 2000);
-						setTimeout(() => msg.edit("I'll give you the first word in **2**"), 3000);
-						setTimeout(() => msg.edit("I'll give you the first word in **1**"), 4000);
-						setTimeout(() => msg.edit("Quick, type the **Korean** word below!"), 5000);
-					}),
-				2000
-			);
-
-			// Send Korean vocab word to chat
-			global.typingGameTimeout = setTimeout(async () => {
-				await message.channel.send(`**${word}** - (${definition})`);
-				global.typingGame.startTime = Date.now() + 500;
-				// 500 ms to approximately account for slight latency
-			}, 7200);
-		} else {
-			await message.channel.send(`**${word}** - (${definition})`);
-			global.typingGame.startTime = Date.now() + 500;
-		}
-
-		// Sets flag showing first round started to true
-		global.tgFirstRoundStarted = true;
-		global.typingGameKey = word;
-	} catch (error) {
-		console.log(error);
-		return;
-	}
-}
-/* ------------------------------------------- */
-
-async function getVocab(message) {
-	// Pulls random word from vocabWords
-	const oldOrNewVocab = Math.floor(Math.random() * 4); //Determines whether user gets old or new vocab
-	const range = oldOrNewVocab < 1 ? "Old Vocab!A2:B" : "Weekly Vocab!A2:B";
-	const vocabList = await GoogleSheets.fetchVocab(range);
-	if (!vocabList) {
-		message.channel.send("I couldn't get the vocab for some reason. Ugh, my makers are useless.\nMaybe we should try again?")
-		endTypingGame(message, false, true);
-		return;
-	}
-	const seed = Math.floor(Math.random() * vocabList.length);
-	return vocabList[seed];
+const GAMES = {
+	[typingGame.gameName]: typingGame
 }
 
-/* _________________ Listens for messages from participants ___________________ */
-
-function typingGameListener(message, client) {
-	try {
-		if (message.content === global.typingGameKey) {
-			/* Sets listener flag to false when user gives the correct answer */
-			global.typingGame.listenerFlag = false;
-			global.typingGameKey = undefined;
-
-			// Creates round counter and increases count
-			global.typingGame.roundCount = global.typingGame.roundCount + 1 || 1;
-
-			const author = message.author;
-
-			//Creates list of winners
-			global.typingGame.winners = global.typingGame.winners || {};
-
-			// Keeps track of how many times a user has won in the round
-			global.typingGame.winners[author] = global.typingGame.winners[author] + 1 || 1;
-
-			// Calculates time elapsed
-			global.typingGame.endTime = Date.now();
-			global.typingGame.elapsed = global.typingGame.endTime - global.typingGame.startTime;
-			const inSeconds = (global.typingGame.elapsed / 1000).toFixed(2);
-			global.typingGame.fullTime = global.typingGame.fullTime || 0;
-			const unroundedNum = parseFloat(global.typingGame.fullTime) + parseFloat(inSeconds);
-			global.typingGame.fullTime = unroundedNum.toFixed(2);
-
-			message.channel.send(`Manomanoman, you sure are good at this!\n**${author} won round ${global.typingGame.roundCount}!**\nI wasn't really counting or anything, but it took you **${inSeconds} seconds**.`);
-
-			if (global.typingGame.roundCount < 5) {
-				setTimeout(
-					() =>
-						message.channel.send(`Round ${global.typingGame.roundCount + 1} starts in **5**`).then((msg) => {
-							setTimeout(() => msg.edit(`Round ${global.typingGame.roundCount + 1} starts in **4**`), 1000);
-							setTimeout(() => msg.edit(`Round ${global.typingGame.roundCount + 1} starts in **3**`), 2000);
-							setTimeout(() => msg.edit(`Round ${global.typingGame.roundCount + 1} starts in **2**`), 3000);
-							setTimeout(() => msg.edit(`Round ${global.typingGame.roundCount + 1} starts in **1**`), 4000);
-							setTimeout(() => msg.edit("Quick, type the Korean word below!"), 5000);
-							setTimeout(() => typingGame(message), 5000);
-						}),
-					1000
-				);
-			} else {
-				const winners = global.typingGame.winners;
-				const fullTime = global.typingGame.fullTime;
-				setTimeout(() => message.channel.send("I'm going to have to bring my A-game next time."), 1000);
-				setTimeout(() => message.channel.send(`__Here are this exercise's **results**__:`), 1250);
-				setTimeout(() => message.channel.send(`You got through the entire thing in a total of **${fullTime}** seconds.`), 1500);
-				Object.keys(winners).forEach((winner) => {
-					setTimeout(() => message.channel.send(`${winner}: ${winners[winner]} wins`), 1600);
-				});
-				// Ends game
-				global.typingGame.listenerFlag = false;
-				global.typingFlag = false;
-				endTypingGame(message);
-			}
-		}
-	} catch (error) {
-		console.log(error);
-		return;
-	}
-}
-/* -------------------------------------------------- */
-
-/* ____________________ Ends Typing Game __________________ */
-
-function endTypingGame(message, wroteStopFlag, noMsg) {
-	if (wroteStopFlag) {
-		if (global.typingFlag) {
-			message.channel.send('Fine, just don\'t ask me to call you "professor fasty fast" anymore.');
-		} else {
-			message.channel.send("We weren't doing any exercises, silly.");
-		}
-	} else if (global.typingFlag && !noMsg) {
-		message.channel.send('Okay, let\'s restart the exercise then, "professor fasty fast".');
-	}
-	clearTimeout(global.typingGameTimeout);
-	global.typingGame = {};
-	// Sets flag showing game is in play to false
-	global.typingFlag = false;
-	global.tgFirstRoundStarted = false;
-}
-/* -------------------------------------------------- */
+let noResponseTimeout = null;
+let explanationTimeout = null;
+let currentGame = null;
 
 /* ___________________ Sends Game Explanation Message _________________ */
 function gameExplanation(message) {
-	const text = message.content ?? "";
-	// Sends typing game explanation
-	if (message.channel.id === process.env.EXERCISES_CHANNEL) {
-		clearTimeout(global.noResponseTimeout);
+	if (!isExercisesChannel(message.channel)) {
+		return;
+	}
 
-		//Ignores messages from the bot unless it's a message signaling end of game
-		if (message.author.bot && !text.includes("wins")) {
-			clearTimeout(global.explanationTimeout);
-			// Ignores typing game explanation message
-			// But sends explanation when game timeout runs out
-			if (!text.includes("!t")) {
-				global.noResponseTimeout = setTimeout(() => {
-					sendResponse(message);
-				}, 30000);
-			}
-			return;
+	// Sends typing game explanation
+	clearTimeout(noResponseTimeout);
+
+	//Ignores messages from the bot unless it's a message signaling end of game
+	if (message.author.bot && !message.content.includes("wins")) {
+		clearTimeout(explanationTimeout);
+		// Ignores typing game explanation message
+		// But sends explanation when game timeout runs out
+		if (!message.content.includes("!t")) {
+			noResponseTimeout = setTimeout(() => {
+				sendResponse(message);
+			}, 30000);
 		}
-		//Clears timeout and starts new timeout for game explanation
-		clearTimeout(global.explanationTimeout);
-		global.explanationTimeout = setTimeout(() => {
-			sendResponse(message);
-		}, 20000);
+		return;
 	}
-	function sendResponse(message) {
-		message.channel.send("...uhh,\n\nAhem... If you would like to start the typing exercise, you can type:\n\n<@!784522323755663411> `typing`\n\n- ***OR*** -\n\n`!t`  or  `!ㅌ`");
-	}
+	//Clears timeout and starts new timeout for game explanation
+	clearTimeout(explanationTimeout);
+	explanationTimeout = setTimeout(() => {
+		sendResponse(message);
+	}, 25000);
 }
 /* ------------------------------------------------- */
 
+function sendResponse(message) {
+	message.channel.send(
+		"...uhh,\n\nAhem... If you would like to start the typing exercise, " +
+		"you can type:\n\n<@!" + process.env.CLIENT_ID + "> `" + GAMES[typingGame.gameName].commands.long +
+		"`\n- ***OR*** -\n`" + GAMES[typingGame.gameName].commands.short + "` or `" + GAMES[typingGame.gameName].commands.hangul + "`"
+	);
+	if (gameIsRunning()) {
+		GAMES[currentGame].endGame();
+		currentGame = null;
+	}
+}
 
-module.exports = { typingGame, typingGameListener, endTypingGame, gameExplanation };
+function shouldStartGame(message, client) {
+	if (!isExercisesChannel(message.channel)) {
+		sendWrongChannelMessage(client, message);
+		return false;
+	}
+	for (let gameIdentifier in GAMES) {
+		if (containsCommandForGame(message.content, gameIdentifier)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function sendWrongChannelMessage(client, message) {
+	client.channels.fetch(process.env.EXERCISES_CHANNEL).then((exerciseChannel) => {
+		message.reply(`Psst...I think you meant to send this in the ${exerciseChannel} channel.\nBut don't worry, no one noticed!`);
+	});
+}
+
+function containsCommandForGame(messageContent, gameName) {
+	if (messageContent.includes(process.env.CLIENT_ID) && messageContent.includes(GAMES[gameName].commands.long)) {
+		return true;
+	}
+	if (messageContent.endsWith(GAMES[gameName].commands.short)) {
+		return true;
+	}
+	return false;
+}
+
+function startGame(message) {
+	if (gameIsRunning()) {
+		endGame(message);
+	}
+
+	setUpCurrentGame(message.content).then(() => {
+		GAMES[currentGame].startGame(message);
+	});
+}
+
+function gameIsRunning() {
+	return Boolean(currentGame) && GAMES[currentGame].gameIsInProgress();
+}
+
+function endGame(message, wroteStopFlag) {
+	handleEndGameMessage(message, wroteStopFlag);
+	if (gameIsRunning()) {
+		GAMES[currentGame].endGame();
+	}
+	currentGame = null;
+}
+
+function handleEndGameMessage(message, wroteStopFlag) {
+	if (wroteStopFlag && !gameIsRunning()) {
+		message.channel.send("We weren't doing any exercises, silly.");
+		return;
+	}
+
+	if (wroteStopFlag) {
+		message.channel.send('Fine, just don\'t ask me to call you "professor fasty fast" anymore.');
+		return;
+	}
+
+	if (gameIsRunning()) {
+		message.channel.send('Okay, let\'s restart the exercise then, "professor fasty fast".');
+		return;
+	}
+}
+
+async function setUpCurrentGame(messageContent) {
+	setGame(messageContent);
+	return await GAMES[currentGame].setUp();
+}
+
+function setGame(messageContent) {
+	for (let gameName in GAMES) {
+		if (containsCommandForGame(messageContent, gameName)) {
+			currentGame = gameName;
+			return;
+		}
+	}
+}
+
+function gameListener(message) {
+	GAMES[currentGame].handleMessageDuringGame(message);
+	if (!gameIsRunning()) {
+		endGame(message, false);
+	}
+}
+
+module.exports = { gameExplanation, shouldStartGame, startGame, endGame, gameIsRunning, gameListener };

--- a/src/scripts/activities/games.js
+++ b/src/scripts/activities/games.js
@@ -71,16 +71,17 @@ function sendWrongChannelMessage(client, message) {
 }
 
 function containsCommandForGame(messageContent, gameName) {
-	if (messageContent.includes(process.env.CLIENT_ID) && messageContent.includes(GAMES[gameName].commands.long)) {
-		return true;
+	const commands = [GAMES[gameName].commands.short, GAMES[gameName].commands.long];
+	if (GAMES[gameName].commands.hangul) {
+		commands.push(GAMES[gameName].commands.short)
 	}
-	const shortCommand = GAMES[gameName].commands?.short;
-	const hangulCommand = GAMES[gameName].commands?.hangul;
-	if (messageContent.endsWith(shortCommand) || messageContent.endsWith(hangulCommand)) {
-		return true;
-	}
-	
-	return false;
+	const commandPrefixRegex = `\!`;
+	const botMentionRegex = `\<\@\!?${process.env.CLIENT_ID}\>\s?${commandPrefixRegex}?`;
+	const gameStartCommandRegex = `${commands.join('|')}`;
+	const commandRegex = new RegExp(
+		`^((${botMentionRegex})|${commandPrefixRegex})(${gameStartCommandRegex})\b`
+	);
+	return commandRegex.test(messageContent);
 }
 
 function startGame(message) {

--- a/src/scripts/activities/typing-game.js
+++ b/src/scripts/activities/typing-game.js
@@ -1,0 +1,164 @@
+const GoogleSheets = require("../../connections/google-sheets-conn");
+
+const gameName = "typingGame";
+const commands = {
+    long: "typing",
+    short: "!t",
+    hangul: "!ㅌ"
+};
+const numberOfRounds = 5;
+let weeklyVocab = {};
+let vocabWords = {};
+
+let gameInProgress = false;
+let roundCount = 0;
+let gameTimeout = null;
+let startTime = null;
+let endTime = null;
+let elapsed = null;
+let fullTime = null;
+let answers = [];
+let winners = {};
+
+async function setUp() {
+    vocabWords = await GoogleSheets.fetchVocab("Old Vocab!A2:B");
+    weeklyVocab = await GoogleSheets.fetchVocab("Weekly Vocab!A2:B");
+    resetGameVariables();
+}
+
+function resetGameVariables() {
+    gameInProgress = false;
+    roundCount = 0;
+    gameTimeout = null;
+    startTime = null;
+    endTime = null;
+    elapsed = null;
+    fullTime = null;
+    answers = getAnswers();
+    winners = {};
+}
+
+function getAnswers() {
+    let answers = [];
+    while (answers.length < numberOfRounds) {
+        answers.push(getOneVocabWord());
+    }
+    return answers;
+}
+
+function getOneVocabWord() {
+    let vocabWord = null;
+    const oldOrNewVocab = Math.floor(Math.random() * 4);
+    const vocabList = oldOrNewVocab < 1 ? vocabWords : weeklyVocab;
+    do {
+        const seed = Math.floor(Math.random() * vocabList.length);
+        vocabWord = vocabList[seed];
+    } while (vocabWordAlreadyUsed(vocabWord))
+
+    return vocabWord;
+}
+
+function vocabWordAlreadyUsed(vocabWord) {
+    return answers.some((answerObject) => {
+        return answerObject.word === vocabWord.word;
+    });
+}
+
+async function startGame(message) {
+    try {
+        gameInProgress = true;
+        const { word, definition } = answers[roundCount];
+
+        if (roundCount === 0) {
+            setTimeout(() => message.channel.send(`So you're professor fasty fast. :smirk:\nWell let's see you type this word in Korean then!`), 1000);
+            setTimeout(
+                () =>
+                    message.channel.send("I'll give you the first word in **5**").then((msg) => {
+                        setTimeout(() => msg.edit("I'll give you the first word in **4**"), 1000);
+                        setTimeout(() => msg.edit("I'll give you the first word in **3**"), 2000);
+                        setTimeout(() => msg.edit("I'll give you the first word in **2**"), 3000);
+                        setTimeout(() => msg.edit("I'll give you the first word in **1**"), 4000);
+                        setTimeout(() => msg.edit("Quick, type the **Korean** word below!"), 5000);
+                    }),
+                2000
+            );
+
+            // Send Korean vocab word to chat
+            gameTimeout = setTimeout(() => {
+                sendChallenge(message, word, definition);
+            }, 7200);
+        } else {
+            sendChallenge(message, word, definition);
+        }
+    } catch (error) {
+        console.log(error);
+        return;
+    }
+}
+
+function sendChallenge(message, word, definition) {
+    message.channel.send(`**${word}** - (${definition})`).then(() => {
+        startTime = Date.now();
+    });
+}
+
+function handleMessageDuringGame(message) {
+    try {
+        if (message.content === answers[roundCount].word) {
+            roundCount = roundCount + 1;
+
+            // Keeps track of how many times a user has won in the round
+            const author = message.author;
+            winners[author] = winners[author] + 1 || 1;
+
+            // Calculates time elapsed
+            endTime = Date.now();
+            elapsed = endTime - startTime;
+            const inSeconds = (elapsed / 1000).toFixed(2);
+            fullTime = fullTime || 0;
+            const unroundedNum = parseFloat(fullTime) + parseFloat(inSeconds);
+            fullTime = unroundedNum.toFixed(2);
+
+            message.channel.send(`Manomanoman, you sure are good at this!\n**${author} won round ${roundCount}!**\nI wasn't really counting or anything, but it took you **${inSeconds} seconds**.`);
+
+            if (roundCount < numberOfRounds) {
+                setTimeout(
+                    () =>
+                        message.channel.send(`Round ${roundCount + 1} starts in **5**`).then((msg) => {
+                            setTimeout(() => msg.edit(`Round ${roundCount + 1} starts in **4**`), 1000);
+                            setTimeout(() => msg.edit(`Round ${roundCount + 1} starts in **3**`), 2000);
+                            setTimeout(() => msg.edit(`Round ${roundCount + 1} starts in **2**`), 3000);
+                            setTimeout(() => msg.edit(`Round ${roundCount + 1} starts in **1**`), 4000);
+                            setTimeout(() => msg.edit("Quick, type the Korean word below!"), 5000);
+                            setTimeout(() => startGame(message), 5000);
+                        }),
+                    1000
+                );
+            } else {
+                setTimeout(() => message.channel.send("I'm going to have to bring my A-game next time."), 1000);
+                setTimeout(() => message.channel.send(`__Here are this exercise's **results**__:`), 1250);
+                setTimeout(() => message.channel.send(`You got through the entire thing in a total of **${fullTime}** seconds.`), 1500);
+                Object.keys(winners).forEach((winner) => {
+                    setTimeout(() => message.channel.send(`${winner}: ${winners[winner]} wins`), 1600);
+                });
+
+                // Clear the current game variable to trigger the endGame function
+                gameInProgress = false;
+            }
+        }
+    } catch (error) {
+        console.log(error);
+        return;
+    }
+}
+
+function endGame() {
+    resetGameVariables();
+    clearTimeout(gameTimeout);
+}
+
+function gameIsInProgress() {
+    return gameInProgress;
+}
+
+module.exports = { gameName, commands, setUp, startGame, handleMessageDuringGame, endGame, gameIsInProgress };

--- a/src/scripts/activities/typing-game.js
+++ b/src/scripts/activities/typing-game.js
@@ -103,6 +103,7 @@ function sendChallenge(message, word, definition) {
 }
 
 function handleMessageDuringGame(message) {
+    if (userRestartedGame(message)) return;
     try {
         if (message.content === answers[roundCount].word) {
             roundCount = roundCount + 1;
@@ -153,12 +154,23 @@ function handleMessageDuringGame(message) {
 }
 
 function endGame() {
-    resetGameVariables();
     clearTimeout(gameTimeout);
+    resetGameVariables();
 }
 
 function gameIsInProgress() {
     return gameInProgress;
+}
+
+function userRestartedGame(message) {
+    Object.keys(commands).forEach((command) => {
+        if (message.content.includes(commands[command])) {
+            endGame();
+            startGame(message);
+            return true;
+        }
+    })
+    return false;
 }
 
 module.exports = { gameName, commands, setUp, startGame, handleMessageDuringGame, endGame, gameIsInProgress };

--- a/src/scripts/utilities.js
+++ b/src/scripts/utilities.js
@@ -14,7 +14,6 @@ function ping(message) {
 	setTimeout(() => {
 		message
 			.reply(" what do you want?")
-			.then(() => { })
 			.catch(console.error);
 		message.channel.stopTyping();
 	}, 7000);
@@ -66,7 +65,7 @@ function unPin50thMsg(channel) {
 				});
 			});
 		}
-	});
+	}).catch(console.error);
 }
 
 function getAllChannels(client) {
@@ -75,12 +74,27 @@ function getAllChannels(client) {
 		client.channels
 			.fetch(chnl.id)
 			.then((fullChannel) => {
+				if (!fullChannel.members.get(client.user.id)) {
+					return;
+				}
 				if (fullChannel.type === "text") {
 					unPin50thMsg(fullChannel);
 				}
 			})
 			.catch(console.error);
 	});
+}
+
+function isExercisesChannel(channel) {
+	return channel.id === process.env.EXERCISES_CHANNEL;
+}
+
+function isKoreanChannel(channel) {
+	return channel.id === process.env.KOREAN_CHANNEL;
+}
+
+function isLinksChannel(channel) {
+	return channel.id === process.env.LINKS_CHANNEL;
 }
 
 function logMessageDate() {
@@ -251,4 +265,4 @@ Results in the bot creating a study session and responding with a message that l
 	});
 }
 
-module.exports = { ping, getPinned, movePinned, unPin50thMsg, getAllChannels, logMessageDate, handleHelpCommand };
+module.exports = { ping, getPinned, movePinned, unPin50thMsg, getAllChannels, logMessageDate, isExercisesChannel, isKoreanChannel, isLinksChannel, handleHelpCommand };


### PR DESCRIPTION
The bulk of this work was done in https://github.com/Fox-Islam/korean-discord-app/pull/1 which is blocked by the translation exercise

Decided to revisit the refactor and handle it ahead of the translation exercise since the refactor is also blocking a couple of PRs open on my fork which are branched off of it

Changes:
- Removed all of the global variables from the game files
- Caught a couple of dangling unhandled promises
- Simplified switch statement in index.js
- Moved typing exercise out into its own file
  - typing-game.js

Future additional exercises should also have their own files which contain all of their business logic, while games.js acts mainly as a dispatcher to call the right game functions from