### PR TITLE
Prevent bug where external emojis are parsed as times

### DIFF
--- a/src/scripts/activities/study-session.js
+++ b/src/scripts/activities/study-session.js
@@ -6,13 +6,13 @@ const { replyInfo, replySuccess, replyError, replySurvey, sendDirectMessage } = 
 function getStudySessionDate(text) {
 	// Regex Declaration
 	const dateRgx = /(\d{4}[-|\/]\d{2}[-|\/]\d{2})/g; // YYYY-MM-DD | YYYY/MM/DD
-	const timeRgx = /(?<hour>\d{1,2}:\d{2})\s?(?<ampm>am|pm)?/gi; // HH:mm | HH:mm am | HH:mm pm
+	const timeRgx = /[\s\n](?<hour>\d{1,2}:\d{2})\s?(?<ampm>am|pm)?/gi; // HH:mm | HH:mm am | HH:mm pm
 
 	// Catching information from message
 	const date = dateRgx.exec(text)?.[1];
 	const { hour, ampm = "" } = timeRgx.exec(text)?.groups ?? {};
 
-	return new Date(`${date} ${hour} ${ampm}`);
+	return new Date(`${date} ${hour} ${ampm} +00:00`);
 }
 
 function getStudySessionEstimatedLength(text) {


### PR DESCRIPTION
External emojis are represented by a string of this form
```
<emoji_name:emoji_id>
```
so an emoji with a name that has a number at the end, like
```
<thinking_face_2:574895743854574354795893>
```
would be picked up by the time-regex for containing `\d{1,2}:\d{2}`

Adds an requirement to have a preceding space or newline

Also contains a fix for the server time bug (where the session gets created using the server's timezone) - adding `+00:00` forces the datetime to be parsed as if it were UTC