### PR TITLE
Allow updating study session date

### DIFF
--- a/src/constants/studySession.js
+++ b/src/constants/studySession.js
@@ -26,6 +26,19 @@ const STUDY_SESSION = {
 			description: "Do you want to create a study session? Please, provide a valid session length!\n\n*Just a reminder, the accepted format is `0 hour(s) and 00 minutes` for the session length.*",
 		},
 	},
+	UPDATE: {
+		SUCCESS: { content: `😉 Roger! Study session has been updated.` },
+		SUCCESS_WITH_SUBSCRIBERS: { content: `😉 Roger! All the participants will be notified in their DMs.` },
+		NOTIFICATION: (author, subscriber, sessionText) => ({
+			content: `Hey ${subscriber.username}! <@${author.id}> just updated a study session which you were subscribed to.`,
+			title: 'Updated study session',
+			description: sessionText
+		}),
+		ERROR: (error) => ({
+			title: "❌ Updating error",
+			description: `Oops! An error as occurred while updating the study session. Please try again!${error ? `\n\n*${error}*` : ""}`,
+		})
+	},
 	UPCOMING: {
 		SUCCESS: (sessions) => ({
 			title: "UPCOMING STUDY SESSIONS",

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const { isDm, handleDmReactionAdd } = require("./scripts/users/dm/dm");
 const { addBookmark, removeBookmark } = require("./scripts/users/dm/bookmarks");
 const { unPin50thMsg, getAllChannels, ping, handleHelpCommand } = require("./scripts/utilities");
 const { typingGame, typingGameListener, endTypingGame, gameExplanation } = require("./scripts/activities/games");
-const { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession } = require("./scripts/activities/study-session");
+const { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession, updateStudySessionDetails } = require("./scripts/activities/study-session");
 const { convertBetweenTimezones } = require("./scripts/utility-commands/time-and-date");
 const { loadMessageReaction } = require("./utils/cache");
 const runScheduler = require("./scheduler").default;
@@ -160,6 +160,11 @@ client.on("message", (message) => {
 
 client.on("messageUpdate", (oldMessage, newMessage) => {
 	explicitWordFilter(newMessage);
+	oldMessage.fetch().then((oldMessage) => {
+		if (oldMessage.content.startsWith("!study")) {
+			updateStudySessionDetails(oldMessage, newMessage);
+		}
+	});
 });
 
 client.on("messageDelete", (message) => {


### PR DESCRIPTION
Currently study sessions need to be deleted and re-created if the date changes - subscribers are notified of the cancellation but not notified that the session has been recreated, which may lead to some confusion.

Added a hook into messageUpdate to allow updating study session start dates (and then notifying any subscribers with the updated session information)