### PR TITLE
Update bot to use dynamic timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "discord.js": "^12.5.1",
     "dotenv": "^8.2.0",
     "googleapis": "^39.2.0",
-    "luxon": "^1.27.0",
     "mongoose": "^5.11.8",
     "node-cron": "^2.0.3"
   },

--- a/src/constants/studySession.js
+++ b/src/constants/studySession.js
@@ -1,4 +1,4 @@
-const { getUTCFullDate, getUTCFullTime } = require("../utils/date");
+const { getDynamicDateTime } = require("../utils/date");
 
 // Study session's related messages
 const STUDY_SESSION = {
@@ -6,7 +6,7 @@ const STUDY_SESSION = {
 		SUCCESS: (session) => ({
 			title: "STUDY SESSION",
 			content: "Study session has been registered successfully!",
-			description: `📆 ${getUTCFullDate(session.startDate, "date")} at ${getUTCFullDate(session.startDate, "time")} *(UTC)*\n🕑 Estimated length: ${session.estimatedLength} minutes.\n\n${getStudySessionText(session.message)}\n\n*If anybody wants to join the session, subscribe using the ⭐ button\nIf you want to cancel the session, delete the message used to create it*`,
+			description: `📆 ${getDynamicDateTime(session.startDate, 'long date time')}\n🕑 Estimated length: ${session.estimatedLength} minutes.\n\n${getStudySessionText(session.message)}\n\n*If anybody wants to join the session, subscribe using the ⭐ button\nIf you want to cancel the session, delete the message used to create it*`,
 			withAuthor: true,
 		}),
 		ERROR: (error) => ({
@@ -45,7 +45,7 @@ const STUDY_SESSION = {
 			content: "Here are the upcoming study sessions:\n*Make sure to check the time zones!*",
 			fields: sessions.map((session) => ({
 				name: `${session.author.username}'s study session`,
-				value: `*${getUTCFullDate(session.startDate)} UTC (${session.estimatedLength} min)*\n${getUpcomingStudySessionSummary(session.message)} - Subscribe [here](${session.message?.link})`,
+				value: `*${getDynamicDateTime(session.startDate, 'short date time')} (${session.estimatedLength} min)*\n${getUpcomingStudySessionSummary(session.message)} - Subscribe [here](${session.message?.link})`,
 			})),
 		}),
 		ERROR: (error) => ({
@@ -62,7 +62,7 @@ const STUDY_SESSION = {
 			content: `👋 Hey ${subscriber.username}, you successfully registered to <@${author.id}> study session! See you soon!`,
 			description: messageContent.substr(6).trim(),
 		}),
-		REMINDER: (studySession, subscriber) => ({ content: `👋 How is your day going, ${subscriber.username}? Thank you for waiting, <@${studySession.author.id}>'s study session is starting in an hour! See you on the Korean Study Group server at **${getUTCFullTime(studySession.startDate)} UTC**!\n*Make sure to check the time zone!*` }),
+		REMINDER: (studySession, subscriber) => ({ content: `👋 How is your day going, ${subscriber.username}? Thank you for waiting, <@${studySession.author.id}>'s study session is starting ${getDynamicDateTime(studySession.startDate, 'relative')}! See you on the Korean Study Group server at **${getDynamicDateTime(studySession.startDate, 'short time')}**!\n` }),
 		ERROR: (author, error) => ({
 			content: `${author.username}, you just tried to subscribe to a study session. Thanks for your participation! However, an error as occurred during the process. Please try again! (and don't hesitate to notify <@202787014502776832> about this error)`,
 			title: "❌ Subscription error",
@@ -138,7 +138,7 @@ function getStudySessionCancellationInformation(studySession) {
 		cancellationMessage = title;
 	}
 
-	return `${cancellationMessage} on ${getUTCFullDate(startDate, "date")} at ${getUTCFullDate(startDate, "time")} *(UTC)* has been cancelled`;
+	return `${cancellationMessage} on ${getDynamicDateTime(startDate, 'long date time')} has been cancelled`;
 }
 
 function getTitle(message) {
@@ -161,7 +161,7 @@ function getStudySessionCancellationSubscriberNotification(studySession) {
 		cancellationMessage = title;
 	}
 
-	return `${cancellationMessage} on ${getUTCFullDate(startDate, "date")} at ${getUTCFullDate(startDate, "time")} *(UTC)*`;
+	return `${cancellationMessage} on ${getDynamicDateTime(startDate, 'long date time')}`;
 }
 
 module.exports = { STUDY_SESSION };

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const { addBookmark, removeBookmark } = require("./scripts/users/dm/bookmarks");
 const { unPin50thMsg, getAllChannels, ping, handleHelpCommand } = require("./scripts/utilities");
 const { typingGame, typingGameListener, endTypingGame, gameExplanation } = require("./scripts/activities/games");
 const { createStudySession, getUpcomingStudySessions, cancelStudySessionFromCommand, cancelStudySessionFromDeletion, subscribeStudySession, unsubscribeStudySession, updateStudySessionDetails } = require("./scripts/activities/study-session");
-const { convertBetweenTimezones } = require("./scripts/utility-commands/time-and-date");
+const { createDynamicTime } = require("./scripts/utility-commands/time-and-date");
 const { loadMessageReaction } = require("./utils/cache");
 const runScheduler = require("./scheduler").default;
 /* ------------------------------------------------------ */
@@ -151,8 +151,8 @@ client.on("message", (message) => {
 		return;
 	}
 
-	if (text.startsWith("!timezone")) {
-		convertBetweenTimezones(message);
+	if (text.startsWith("!time")) {
+		createDynamicTime(message);
 		return;
 	}
 });

--- a/src/scripts/utilities.js
+++ b/src/scripts/utilities.js
@@ -88,8 +88,8 @@ function logMessageDate() {
 }
 
 function handleHelpCommand(message) {
-	if (message.content.startsWith('!help timezone')) {
-		handleHelpTimezoneCommand(message);
+	if (message.content.startsWith('!help time')) {
+		handleHelpTimeCommand(message);
 		return;
 	}
 	if (message.content.startsWith('!help cancel study')) {
@@ -119,11 +119,11 @@ You can cancel a study session either by deleting the message used to create the
 					`
 				},
 				{
-					name: 'Timezones',
+					name: 'Time',
 					value: `
-Use \`!timezone\` to convert a date-time to equivalent date-times in different regions
+Use \`!time\` to generate a dynamic date-time which shows the correct time to each user based on their local timezone
 
-Use \`!help timezone\` for more information
+Use \`!help time\` for more information
 					`
 				}, {
 					name: 'Bookmarks',
@@ -143,36 +143,40 @@ Any message the bot sends via DM can be deleted by applying an 'x' (❌) reactio
 	});
 }
 
-function handleHelpTimezoneCommand(message) {
+function handleHelpTimeCommand(message) {
+	const currentTime = Math.round(new Date().getTime() / 1000);
 	message.channel.send(null, {
 		embed: {
-			title: "The !timezone command",
+			title: "The !time command",
 			fields: [
 				{
 					name: 'Description',
-					value: 'The `!timezone` command can be used to convert a date-time into date-times around the world'
+					value: 'The `!time` command can be used to generate a dynamic date-time'
 				}, {
 					name: 'Format',
 					value: `
-This requires a date in the format YYYY/MM/DD and a UTC time in HH:mm followed by any number of [TZ database names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)
+This command optionally takes a UTC date-time in the format YYYY/MM/DD HH:mm and an output type
+
+If a date is not supplied it will use the current date and time
+If an output type is not supplied it will use the default output type ("short date time")
 					`
 				}, {
-					name: 'Example',
+					name: 'Examples',
 					value: `
-If you've created a study session with these details
-\`\`\`
-!study 2022/03/05 at 13:30 ...
-\`\`\`
-You can get the equivalent date-times in Toronto, London and Seoul using
-\`\`\`
-!timezone 2022/03/05 13:30 America/Toronto Europe/London Asia/Seoul
-\`\`\`
-Which creates this response:
-\`\`\`
-Sat, 5 Mar at 08:30 (Eastern Standard Time)
-Sat, 5 Mar at 13:30 (Greenwich Mean Time)
-Sat, 5 Mar at 22:30 (Korean Standard Time)
-\`\`\`
+\`!time\` on its own will generate <t:${currentTime}:f>
+\`!time short time\` will generate <t:${currentTime}:t>
+\`!time 2021/07/29 22:00 relative\` will generate <t:1627592400:R>
+					`
+				}, {
+					name: 'Output types',
+					value: `
+short date: <t:${currentTime}:d>
+long date: <t:${currentTime}:D>
+short time: <t:${currentTime}:t>
+long time: <t:${currentTime}:T>
+short date time: <t:${currentTime}:f>
+long date time: <t:${currentTime}:F>
+relative: <t:${currentTime}:R>
 					`
 				}
 			]

--- a/src/tasks/studySession/channelReminder.js
+++ b/src/tasks/studySession/channelReminder.js
@@ -1,5 +1,5 @@
 const { getUpcomingStudySessionsForScheduler } = require('../../scripts/activities/study-session');
-const { getUTCFullDate } = require("../../utils/date");
+const { getDynamicDateTime } = require("../../utils/date");
 
 const upcomingStudySessionMessageContent = "Here are the upcoming study sessions:\n*Make sure to check the time zones!*";
 const oneHour = 60 * 60 * 1000;
@@ -69,7 +69,7 @@ function makeStudySessionMessage() {
                 title: "UPCOMING STUDY SESSIONS",
                 fields: upcomingStudySessions.map((session) => ({
                     name: `${session.author.username}'s study session`,
-                    value: `*${getUTCFullDate(session.startDate)} UTC (${session.estimatedLength} min)*\n${getUpcomingStudySessionSummary(session.message)} - Subscribe [here](${session.message?.link})`,
+                    value: `*${getDynamicDateTime(session.startDate, 'short date time')} (${session.estimatedLength} min)*\n${getUpcomingStudySessionSummary(session.message)} - Subscribe [here](${session.message?.link})`,
                 })),
                 color: "GREEN"
             }

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,31 +1,23 @@
-function getUTCFullDate(date, separateIntoGroups = "") {
-	if (!date) return "";
-	const dateUTC = date.toUTCString();
+const DATE_FORMAT = Object.freeze({
+	SHORT_DATE_TIME: 'f',
+	LONG_DATE_TIME: 'F',
+	SHORT_DATE: 'd',
+	LONG_DATE: 'D',
+	SHORT_TIME: 't',
+	LONG_TIME: 'T',
+	RELATIVE: 'R'
+});
 
-	// Optionally separate date, year, time, and timezone into groups
-	const separateRegEx = /(?<onlyDate>\w{3},\s\d+\s\w{3})\s(?<year>\d{4})\s(?<time>\d+:\d+).+(?<zone>\w{3})/;
-	const { onlyDate, year, time, zone } = dateUTC.match(separateRegEx).groups;
-	switch (separateIntoGroups) {
-		case "date":
-			return onlyDate;
-		case "year":
-			return year;
-		case "time":
-			return time;
-		case "zone":
-			return zone;
-	}
-
-	return dateUTC.substr(0, dateUTC.length - 7); // Remove seconds and GMT string
+function getDynamicDateTime(date, outputFormat) {
+	const format = outputFormat ? DATE_FORMAT[outputFormat.toUpperCase().replaceAll(' ', '_')] : 'f'
+	return `<t:${removeMilliseconds(date)}:${format}>`
 }
 
-function getUTCFullTime(date) {
-	if (!date) return "";
-	const hour = date.getUTCHours();
-	const min = date.getUTCMinutes();
-	const fullHour = hour >= 10 ? hour : `0${hour}`;
-	const fullMin = min > 10 ? min : `0${min}`;
-	return `${fullHour}:${fullMin}`;
+/**
+ * @description JavaScript includes milliseconds but Discord's dynamic datetime feature only supports up to second precision
+ */
+function removeMilliseconds(date) {
+	return Math.round(date.getTime() / 1000);
 }
 
-module.exports = { getUTCFullDate, getUTCFullTime };
+module.exports = { getDynamicDateTime, DATE_FORMAT };


### PR DESCRIPTION
Discord recently introduced [dynamic in-line timestamps](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles) which appear different to users based on their local timezone

- Updated study session messages to use dynamic timezones to make scheduled event times clearer

This also made the previously-introduced `!timezone` command obsolete
- Replaced `!timezone` command with `!time` command which can be used by members to generate dynamic timestamps
- Replaced `!help timezone` command with `!help time` command for additional information
- Removed 'luxon' package, which was added only for the `!timezone` command